### PR TITLE
Problem: no Nix derivation for the hugo site

### DIFF
--- a/fractalide-hugo-theme/exampleSite/default.nix
+++ b/fractalide-hugo-theme/exampleSite/default.nix
@@ -1,0 +1,21 @@
+{ bootPkgs ? import <nixpkgs> {}
+, pinnedPkgsSrc ? bootPkgs.fetchFromGitHub { owner = "NixOS"; repo = "nixpkgs-channels";
+  rev = "ea145b68a019f6fff89e772e9a6c5f0584acc02c";
+  sha256 = "18jr124cbgc5zvawvqvvmrp8lq9jcscmn5sg8f5xap6qbg1dgf22"; }
+, pkgs ? import pinnedPkgsSrc {}
+, stdenvNoCC ? pkgs.stdenvNoCC
+, hugo ? pkgs.hugo
+}:
+
+stdenvNoCC.mkDerivation {
+  name = "site";
+  buildInputs = [ hugo ];
+  src = builtins.filterSource (path: type: type != "symlink" || null == builtins.match "result.*" (baseNameOf path)) ./..;
+  buildPhase = ''
+    cd exampleSite
+    hugo
+  '';
+  installPhase = ''
+    cp -a public $out
+  '';
+}


### PR DESCRIPTION
Solution: Create exampleSite/default.nix.

As an unintended side-effect, I just realized that this also means you can run `nix-shell --run 'hugo server'` in the directory, and that will pull down hugo and Just Work.