### PR TITLE
Problem: our new site is in hugo

### DIFF
--- a/new-site/conf.nix
+++ b/new-site/conf.nix
@@ -1,0 +1,14 @@
+{ lib }:
+{
+  /* URL of the site, must be set to the url of the domain the site will be deployed.
+     Should not end with a '/'.
+  */
+  siteUrl = "http://fractalide.com";
+
+  /* Theme specific settings
+     it is possible to override any of the used themes configuration in this set.
+  */
+  theme = {
+    site.title = "Fractalide";
+  };
+}

--- a/new-site/content/index.md
+++ b/new-site/content/index.md
@@ -1,0 +1,5 @@
+{{ site-partials.stack }}
+{{ site-partials.hyperflow }}
+{{ site-partials.fractalmarket }}
+{{ site-partials.cardano }}
+{{ site-partials.signup }}

--- a/new-site/default.nix
+++ b/new-site/default.nix
@@ -1,0 +1,11 @@
+{ bootPkgs ? import <nixpkgs> {}
+, pinnedPkgsSrc ? bootPkgs.fetchFromGitHub { owner = "NixOS"; repo = "nixpkgs-channels";
+  rev = "ea145b68a019f6fff89e772e9a6c5f0584acc02c";
+  sha256 = "18jr124cbgc5zvawvqvvmrp8lq9jcscmn5sg8f5xap6qbg1dgf22"; }
+, pkgs ? import pinnedPkgsSrc {}
+}:
+
+let
+  site-attrs = (pkgs.callPackage (import ./site.nix) {});
+in
+  site-attrs.site // site-attrs

--- a/new-site/site.nix
+++ b/new-site/site.nix
@@ -1,0 +1,89 @@
+/*-----------------------------------------------------------------------------
+   Init
+
+   Initialization of Styx, should not be edited
+-----------------------------------------------------------------------------*/
+{ styx
+, extraConf ? {}
+}:
+
+rec {
+
+  /* Importing styx library
+  */
+  styxLib = import styx.lib styx;
+
+
+/*-----------------------------------------------------------------------------
+   Themes setup
+
+-----------------------------------------------------------------------------*/
+
+  /* Importing styx themes from styx
+  */
+  styx-themes = import styx.themes;
+
+  /* list the themes to load, paths or packages can be used
+     items at the end of the list have higher priority
+  */
+  themes = [
+    styx-themes.generic-templates
+    ./themes/fractalide
+    ./themes/fractalide-site
+  ];
+
+  /* Loading the themes data
+  */
+  themesData = styxLib.themes.load {
+    inherit styxLib themes;
+    extraEnv = { inherit data pages; };
+    extraConf = [ ./conf.nix extraConf ];
+  };
+
+  /* Bringing the themes data to the scope
+  */
+  inherit (themesData) conf lib files templates env;
+
+
+/*-----------------------------------------------------------------------------
+   Data
+
+   This section declares the data used by the site
+-----------------------------------------------------------------------------*/
+
+  data = {
+  };
+
+
+/*-----------------------------------------------------------------------------
+   Pages
+
+   This section declares the pages that will be generated
+-----------------------------------------------------------------------------*/
+
+  pages = rec {
+    index = rec {
+      title    = "Home";
+      path     = "/index.html";
+      template = templates.block-page.full;
+      layout   = templates.layout;
+      blocks   = [ content ];
+      content  = lib.loadFile { file = ./content/index.md; env = { inherit (templates) site-partials; }; };
+    };
+  };
+
+
+/*-----------------------------------------------------------------------------
+   Site
+
+-----------------------------------------------------------------------------*/
+
+  /* Converting the pages attribute set to a list
+  */
+  pageList = lib.pagesToList { inherit pages; };
+
+  /* Generating the site
+  */
+  site = lib.mkSite { inherit files pageList; };
+
+}

--- a/new-site/themes/fractalide-site/meta.nix
+++ b/new-site/themes/fractalide-site/meta.nix
@@ -1,0 +1,4 @@
+{ lib }:
+{
+  id = "fractalide-site";
+}

--- a/new-site/themes/fractalide-site/templates/site-partials-content/cardano.md
+++ b/new-site/themes/fractalide-site/templates/site-partials-content/cardano.md
@@ -1,0 +1,52 @@
+<section id="cardano">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="text-center">
+                    <h1 class="section_heading_blue fractal_blue">Cardano</h1>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-offset-3 col-md-6">
+                <div class="text-center">
+                    <h2 class="sub_heading_blue">A secure, scalable blockchain</h2>
+                    <p>
+                        Designed from first principles, the Cardano blockchain will be amongst the most powerful, customizable, scalable platforms out there. Fractalide will be based on Cardano.
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-offset-2 col-md-8">
+                <div class="text-center">
+                    <h2 class="sub_heading_blue">Reasons for choosing Cardano</h2>
+                </div>
+                <div class="text-left">
+                    <ul>
+                        <li>
+                            <span>
+                                Cardano is designed in layers, separating money from the machine. The Settlement Layer and Computation Layer exist independently of each other. This very same design feature allows scaling up to potentially millions of people.
+                            </span>
+                        </li>
+                        <li>
+                            <span>
+                                The work of Philip Wadler and Grigore Rosu et al have taken important steps to secure the smart contract programming languages. Preventing situations like the Ethereum DAO cracking event and the Parity multi-sig debacle.
+                            </span>
+                        </li>
+                        <li>
+                            <span>
+                                Cardano implements Ouroboros, a provably secure Proof of Stake consensus algorithm designed by Aggelos Kiayias.
+                            </span>
+                        </li>
+                        <li>
+                            <span>
+                                A treasury using Liquid Democracy takes steps at ensuring Cardano is properly maintained well into the future.
+                            </span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/new-site/themes/fractalide-site/templates/site-partials-content/fractalmarket.md
+++ b/new-site/themes/fractalide-site/templates/site-partials-content/fractalmarket.md
@@ -1,0 +1,52 @@
+<section id="fractalmarket">
+    <div class="gradient_top"></div>
+    <div class="solid">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12">
+                    <div class="text-center">
+                        <h1 class="section_heading_blue fractal_white">Fractalmarket</h1>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-lg-offset-3 col-lg-6 col-xs-12">
+                    <div class="text-center">
+                        <h2 class="sub_heading_white">A cryptocontract app marketplace</h2>
+                        <p>
+                            Hyperflow components, cards and stacks should be shared with people. This will be
+                            done via Fractalmarket.
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-lg-4 col-xs-12 text-center">
+                    <div class="feature">
+                        <img src="/img/icon-buy-min.png" />
+                        <p>
+                            Buy and sell components, cards and stacks using <strong>ADA</strong>.
+                        </p>
+                    </div>
+                </div>
+                <div class="col-lg-4 col-xs-12 text-center">
+                    <div class="feature">
+                        <img src="/img/icon-search-min.png" />
+                        <p>
+                            Easily find then drag-and-drop components, designed to interface with smart contracts, into cards and stacks .
+                        </p>
+                    </div>
+                </div>
+                <div class="col-lg-4 col-xs-12 text-center">
+                    <div class="feature">
+                        <img src="/img/icon-align-min.png" />
+                        <p>
+                            Fractalmarket rewards people for creating and using reusable components, cards and stacks.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="gradient_bottom"></div>
+</section>

--- a/new-site/themes/fractalide-site/templates/site-partials-content/hyperflow.md
+++ b/new-site/themes/fractalide-site/templates/site-partials-content/hyperflow.md
@@ -1,0 +1,56 @@
+<section id="hyperflow">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="text-center">
+                    <h1 class="section_heading_blue fractal_blue">Hyperflow</h1>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-offset-3 col-md-6 col-xs-12">
+                <div class="text-center">
+                    <h2 class="sub_heading_blue">A Browser and Rapid Application Development platform for normal people</h2>
+                    <p>
+                         Hyperflow is a browser of smart contracts apps. It draws much inspiration from HyperCard, by allowing non-technical people to easily build and run problem solving apps. Though we will differ from HyperCard on these points.
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-2 col-xs-12 concept_icon">
+                <img src="/img/icon-stack-min.png" width="83px" />
+            </div>
+            <div class="col-lg-4 col-xs-12 concept_info">
+                <h2 class="sub_heading_blue">Hypercard concepts to keep</h2>
+                <p>
+                    The intuitive, and easy to learn approach HyperCard is famous for.
+                </p>
+                <p>
+                    It’s very easy to try out your newly built app, by simply switching between run mode and design mode.
+                </p>
+                <p>
+                    Keep the concept of <strong>cards</strong> and <strong>stacks</strong>, an analogy would be; a card is a webpage and a stack is a website. Each card contains GUI components and logic that links other cards together to form a stack of cards.
+                </p>
+                <p>
+                    Cards, stacks and low level components are shareable via Fractalmarket.
+                </p>
+            </div>
+            <div class="col-lg-2 col-xs-12 text-center concept_icon">
+                <img src="/img/icon-share-min.png" width="90px" />
+            </div>
+            <div class="col-lg-4 col-xs-12 concept_info">
+                <h2 class="sub_heading_blue">Hypercard concepts to remove</h2>
+                <p>
+                    Remove the HyperTalk programming language and replace it with Flowscript, a Flow-based Programming language that promotes reusability.
+                </p>
+                <p>
+                    HyperCard didn't have a network layer, it should go without saying, but this will be corrected.
+                </p>
+                <p>
+                    HyperCard is old and outdated. Hyperflow will be a fresh new take on HyperCard, being completely rewritten from scratch.
+                </p>
+            </div>
+        </div>
+    </div>
+</section>

--- a/new-site/themes/fractalide-site/templates/site-partials-content/signup.md
+++ b/new-site/themes/fractalide-site/templates/site-partials-content/signup.md
@@ -1,0 +1,28 @@
+<section id="signup">
+    <div class="footer_background_home">
+        <div class="footer_content_signup">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="text-center">
+                            <h1 class="section_heading_white">Sign up for early access</h1>
+                            <p class="text_white">
+                                You will get the latest news about Fractalmarket.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-offset-4 col-md-4 col-sm-offset-3 col-sm-6 col-xs-offset-2 col-xs-8">
+                        <form class="signup_form">
+                            <div class="form-group">
+                                <input type="email" class="form-control input-lg" id="email" placeholder="Enter your email">
+                            </div>
+                            <button type="submit" class="btn btn-lg btn-default btn-block">Submit</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/new-site/themes/fractalide-site/templates/site-partials-content/stack.md
+++ b/new-site/themes/fractalide-site/templates/site-partials-content/stack.md
@@ -1,0 +1,20 @@
+<section id="stack">
+    <div class="header_background">
+        <div class="header_content_stack">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-offset-2 col-md-8">
+                        <div class="text-center">
+                            <img src="/img/stack-min.png" width="121px" />
+                            <h1 class="section_heading_white">A Smart Contract App Marketplace</h1>
+                            <p class="text_white">
+                                You don’t have to be a programmer to use smart contracts.<br>Fractalide is an app store linked to a new browser, allowing you to run, create, buy and sell apps.
+                            </p>
+                            <button class="btn btn-lg btn-default">Sign up for early access</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/new-site/themes/fractalide-site/templates/site-partials.nix
+++ b/new-site/themes/fractalide-site/templates/site-partials.nix
@@ -1,0 +1,12 @@
+env:
+
+let
+  contentList = env.lib.loadDir {
+    dir = ./site-partials-content;
+  };
+  attrs = builtins.listToAttrs (map (fileAttrs: {
+    name = fileAttrs.fileData.basename;
+    value = fileAttrs.content;
+  }) contentList);
+in
+  attrs

--- a/new-site/themes/fractalide/meta.nix
+++ b/new-site/themes/fractalide/meta.nix
@@ -1,0 +1,4 @@
+{ lib }:
+{
+  id = "fractalide-theme";
+}


### PR DESCRIPTION
Solution: Start writing a port to styx.

First out is a minimal index.html, without layouts or anything, just
the content. And a bunch of scaffolding for filling in the rest bit
by bit.

The partials are in "markdown format", but it's just the html files
renamed. Rather than going about adding html as a passthrough file
type to styx, this is a decent quick workaround.

Any references to `{{ .Site.BaseURL }}` I simply replaced with `/`.

I found it confusing that what is more like static page content was
put among the more generic layouts and templates, so I separated it
into a `fractalide` theme for framing elements like header and footer
and generic page layouts, and a `fractalide-site` theme for elements
called from page content.

If this doesn't make sense to anyone else, `fractalide` and
`fractalide-site` are trivial to just smash together.

Build the new site with `nix-build new-site`.