### PR TITLE
Problem: new-site head incomplete

### DIFF
--- a/new-site/themes/fractalide/templates/partials/head/css-custom.nix
+++ b/new-site/themes/fractalide/templates/partials/head/css-custom.nix
@@ -3,6 +3,10 @@ env:
 let template = env: page: ''
   <link href="/css/bootstrap-fractalide.min.css" rel="stylesheet">
   <link href="/css/custom.css" rel="stylesheet">
+  <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+  <![endif]-->
 '';
 
 in with env.lib; documentedTemplate {

--- a/new-site/themes/fractalide/templates/partials/head/meta.nix
+++ b/new-site/themes/fractalide/templates/partials/head/meta.nix
@@ -1,0 +1,34 @@
+env:
+
+let template = env: args:
+let
+  lib = env.lib;
+  conf = env.conf;
+  page = args.page;
+in
+  ''
+    <meta charset="utf-8">
+    <meta name="robots" content="all,follow">
+    <meta name="googlebot" content="index,follow,snippet,archive">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="keywords" content="fractalide, styx">
+    <meta name="generator" content="Styx 0.7.1" />
+    <meta property="og:title" content="${lib.optionalString (page ? title) page.title}${lib.optionalString ((lib.hasAttrByPath ["theme" "site" "title"] conf) && (page ? title)) " - "}${lib.optionalString (lib.hasAttrByPath ["theme" "site" "title"] conf) conf.theme.site.title}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="${conf.siteUrl + page.path}" />
+    <meta property="og:image" content="/img/logo.png" />
+  '';
+
+in with env.lib; documentedTemplate {
+  description = ''
+    Generic `meta` tags, should be overriden to fit needs. +
+    Default contents:
+
+    +
+    [source, html]
+    ----
+    ${template env {}}
+    ----
+  '';
+  inherit env template;
+}

--- a/new-site/themes/fractalide/templates/partials/head/title-post-extra.nix
+++ b/new-site/themes/fractalide/templates/partials/head/title-post-extra.nix
@@ -1,0 +1,14 @@
+env:
+
+let template = env: page: ''
+  <link rel="shortcut icon" href="/img/favicon.ico" type="image/x-icon" />
+  <link rel="apple-touch-icon" href="/img/apple-touch-icon.png" />
+  <link rel="alternate" href="/index.xml" type="application/rss+xml" title="Fractalide">
+'';
+
+in with env.lib; documentedTemplate {
+  description = ''
+    Template to add custom extra content in `head`. Empty by default, should be overriden to fit needs.
+  '';
+  inherit env template;
+}


### PR DESCRIPTION
Solution: Add missing elements.

Known issues: If rendered as template documentation, the
documentedTemplate in fractalide/.../meta.nix will fail.
(because it assumes that it gets a `page`)