### PR TITLE
Problem: footer is incomplete

### DIFF
--- a/new-site/conf.nix
+++ b/new-site/conf.nix
@@ -14,5 +14,6 @@
     lib.bootstrap = { enable = true; version = "3.3.7"; };
     lib.font-awesome = { enable = true; version = "4.7.0"; };
     lib.googlefonts = [ "Nunito+Sans:400,900" ];
+    lib.jquery = { enable = true; version = "3.1.1"; };
   };
 }

--- a/new-site/themes/fractalide-site/templates/partials/content-post.nix
+++ b/new-site/themes/fractalide-site/templates/partials/content-post.nix
@@ -1,0 +1,12 @@
+env:
+
+let template = env: args:
+  let site-partials = env.templates.site-partials;
+  in site-partials.footer;
+
+in with env.lib; documentedTemplate {
+  description = ''
+    Template rendering the page post-contents, usually used to render the footer. Empty by default.
+  '';
+  inherit env template;
+}

--- a/new-site/themes/fractalide-site/templates/site-partials-content/footer.md
+++ b/new-site/themes/fractalide-site/templates/site-partials-content/footer.md
@@ -1,0 +1,13 @@
+<section id="copyright" class="footer_solid">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="text-center">
+                    <p class="text_white">
+                        Copyright ©2017 Fractalide. All Rights Reserved.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
Solution: hugo footer.html -> fractalide-site footer.md. jquery.

/index.html should now be functionally the same as in hugo.

Known differences:
 - whitespace
 - some things reordered
 - lang
 - missing <div id="all"> but seems unused (looked for any #all
   references)
 - no integrity attributes on JS links
 - https://fractalide.com/ replaced with / in several places
 - alt text on twitter icon

To compare, do:
    $ nix-build --out-link hugo nix-build --out-link hugo fractalide-hugo-theme/exampleSite
    $ nix-build new-site
    $ diff -ubB hugo/index.html result/index.html