### PR TITLE
Problem: .Site.BaseURL is redundant

### DIFF
--- a/fractalide-hugo-theme/layouts/404.html
+++ b/fractalide-hugo-theme/layouts/404.html
@@ -11,13 +11,13 @@
                 <div class="col-sm-6 col-sm-offset-3" id="error-page">
                     <div class="box">
                         <p class="text-center">
-                            <a href="{{ .Site.BaseURL }}">
+                            <a href="/">
                                 <img src="{{ .Site.Params.logo }}" alt="{{ .Title }} logo">
                             </a>
                         </p>
                         <h3>We are sorry - this page is not here anymore</h3>
                         <h4 class="text-muted">Error 404 - Page not found</h4>
-                        <p class="buttons"><a href="{{ .Site.BaseURL }}" class="btn btn-template-main"><i class="fa fa-home"></i> Go to Homepage</a>
+                        <p class="buttons"><a href="/" class="btn btn-template-main"><i class="fa fa-home"></i> Go to Homepage</a>
                         </p>
                     </div>
                 </div>

--- a/fractalide-hugo-theme/layouts/about_us/single.html
+++ b/fractalide-hugo-theme/layouts/about_us/single.html
@@ -29,12 +29,12 @@
         <div class="row">
             {{ range sort .Site.Data.team "weight" }}
             <div class="col-md-4 col-xs-12 text-center team_member">
-                <img src="{{ .Site.BaseURL }}../img/{{ .image }}" />
+                <img src="/img/{{ .image }}" />
                 <h2 class="sub_heading_blue">{{ .name }}</h2>
                 <p>{{ .title }}</p>
                 {{ range .networks }}
                 <a href="{{ .url }}" target="_blank" rel="external">
-                    <img src="{{ .Site.BaseURL }}../img/{{ .icon }}" width="30px" />
+                    <img src="/img/{{ .icon }}" width="30px" />
                 </a>
                 {{ end }}
             </div>

--- a/fractalide-hugo-theme/layouts/blog/list.html
+++ b/fractalide-hugo-theme/layouts/blog/list.html
@@ -26,9 +26,9 @@
                           <div class="image">
                               <a href="{{ .Permalink }}">
                                   {{ if .Params.banner }}
-                                  <img src="{{ .Site.BaseURL }}{{ .Params.banner }}" class="img-responsive" alt="">
+                                  <img src="/{{ .Params.banner }}" class="img-responsive" alt="">
                                   {{ else }}
-                                  <img src="{{ .Site.BaseURL }}img/placeholder.png" class="img-responsive" alt="">
+                                  <img src="/img/placeholder.png" class="img-responsive" alt="">
                                   {{ end }}
                               </a>
                           </div>

--- a/fractalide-hugo-theme/layouts/blog/single.html
+++ b/fractalide-hugo-theme/layouts/blog/single.html
@@ -49,7 +49,7 @@
             <div class="col-xs-6 col-sm-4 col-sm-offset-2">
                 <ul class="pagination">
                     <li>
-                        <a class="page-link" href="{{ .Site.BaseURL }}blog/" title="All posts" aria-label="All posts">
+                        <a class="page-link" href="/blog/" title="All posts" aria-label="All posts">
                             <i class="fa fa-angle-left text_blue" aria-hidden="true"></i> View all blog post
                         </a>
                     </li>

--- a/fractalide-hugo-theme/layouts/fractalmarket/single.html
+++ b/fractalide-hugo-theme/layouts/fractalmarket/single.html
@@ -34,7 +34,7 @@
         <div class="row">
             <div class="col-lg-4 col-xs-12 text-center">
                 <div class="feature">
-                    <img src="{{ .Site.BaseURL }}img/icon-buy-min.png" />
+                    <img src="/img/icon-buy-min.png" />
                     <p>
                         Buy and sell components, cards and stacks using <strong>ADA</strong>.
                     </p>
@@ -42,7 +42,7 @@
             </div>
             <div class="col-lg-4 col-xs-12 text-center">
                 <div class="feature">
-                    <img src="{{ .Site.BaseURL }}img/icon-search-min.png" />
+                    <img src="/img/icon-search-min.png" />
                     <p>
                         Easily find then drag-and-drop components, designed to interface with smart contracts, into cards and stacks.
                     </p>
@@ -50,7 +50,7 @@
             </div>
             <div class="col-lg-4 col-xs-12 text-center">
                 <div class="feature">
-                    <img src="{{ .Site.BaseURL }}img/icon-align-min.png" />
+                    <img src="/img/icon-align-min.png" />
                     <p>
                         Fractalmarket rewards people for creating and using reusable components, cards and stacks.
                     </p>

--- a/fractalide-hugo-theme/layouts/hyperflow/single.html
+++ b/fractalide-hugo-theme/layouts/hyperflow/single.html
@@ -24,7 +24,7 @@
         </div>
         <div class="row">
             <div class="col-lg-2 col-xs-12 concept_icon">
-                <img src="{{ .Site.BaseURL }}img/icon-stack-min.png" width="83px" />
+                <img src="/img/icon-stack-min.png" width="83px" />
             </div>
             <div class="col-lg-4 col-xs-12 concept_info">
                 <h2 class="sub_heading_blue">Hypercard concepts to keep</h2>
@@ -42,7 +42,7 @@
                 </p>
             </div>
             <div class="col-lg-2 col-xs-12 text-center concept_icon">
-                <img src="{{ .Site.BaseURL }}img/icon-share-min.png" width="90px" />
+                <img src="/img/icon-share-min.png" width="90px" />
             </div>
             <div class="col-lg-4 col-xs-12 concept_info">
                 <h2 class="sub_heading_blue">Hypercard concepts to remove</h2>
@@ -68,7 +68,7 @@
         <div class="row">
             <div class="col-md-offset-1 col-md-4">
                 <div class="hyperflow_mode_top">
-                    <img src="{{ .Site.BaseURL }}img/hyperflow-min/node@2x-min.png" width="317px" />
+                    <img src="/img/hyperflow-min/node@2x-min.png" width="317px" />
                 </div>
             </div>
             <div class="col-md-6">
@@ -86,7 +86,7 @@
         <div class="row">
             <div class="col-md-offset-1 col-md-4">
                 <div class="hyperflow_mode_mid">
-                    <img src="{{ .Site.BaseURL }}img/hyperflow-min/graph@2x-min.png" width="317px" />
+                    <img src="/img/hyperflow-min/graph@2x-min.png" width="317px" />
                 </div>
             </div>
             <div class="col-md-6">
@@ -101,7 +101,7 @@
         <div class="row">
             <div class="col-md-offset-1 col-md-4">
                 <div class="hyperflow_mode_bottom">
-                    <img src="{{ .Site.BaseURL }}img/hyperflow-min/run@2x-min.png" width="317px" />
+                    <img src="/img/hyperflow-min/run@2x-min.png" width="317px" />
                 </div>
             </div>
             <div class="col-md-6">

--- a/fractalide-hugo-theme/layouts/partials/head.html
+++ b/fractalide-hugo-theme/layouts/partials/head.html
@@ -27,8 +27,8 @@
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 
   <!-- Custom stylesheet - for your changes -->
-  <link href="{{ .Site.BaseURL }}css/bootstrap-fractalide.min.css" rel="stylesheet">
-  <link href="{{ .Site.BaseURL }}css/custom.css" rel="stylesheet">
+  <link href="/css/bootstrap-fractalide.min.css" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
 
   <!-- Responsivity for older IE -->
   {{ `
@@ -39,8 +39,8 @@
   ` | safeHTML }}
 
   <!-- Favicon and apple touch icons-->
-  <link rel="shortcut icon" href="{{ .Site.BaseURL }}img/favicon.ico" type="image/x-icon" />
-  <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}img/apple-touch-icon.png" />
+  <link rel="shortcut icon" href="/img/favicon.ico" type="image/x-icon" />
+  <link rel="apple-touch-icon" href="/img/apple-touch-icon.png" />
 
   <link rel="alternate" href="{{ "/index.xml" | absURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
 

--- a/fractalide-hugo-theme/layouts/partials/main.html
+++ b/fractalide-hugo-theme/layouts/partials/main.html
@@ -7,7 +7,7 @@
                     <p>
                         Hyperflow is a browser of smart contracts apps and cryptocurrencies. It draws much inspiration from HyperCard, by allowing people to easily build and run problem solving apps.
                     </p>
-                    <a class="" href="{{ .Site.BaseURL }}hyperflow/">Learn more</a>
+                    <a class="" href="/hyperflow/">Learn more</a>
                 </div>
             </div>
             <div class="col-md-6">
@@ -16,7 +16,7 @@
                     <p>
                         Hyperflow is connected to the app marketplace Fractalmarket. This provides a place for people to upload, share and sell their Hyperflow applications.
                     </p>
-                    <a class="" href="{{ .Site.BaseURL }}fractalmarket/">Learn more</a>
+                    <a class="" href="/fractalmarket/">Learn more</a>
                 </div>
             </div>
         </div>
@@ -27,7 +27,7 @@
                     <p>
                         Blockchain Development, Hyperflow App Development and Technical Analysis as developing software in Fractalide reduces development costs due to reusable, reproducible and composable components.
                     </p>
-                    <a class="" href="{{ .Site.BaseURL }}development-and-analysis/">Learn more</a>
+                    <a class="" href="/development-and-analysis/">Learn more</a>
                 </div>
             </div>
             <div class="col-md-6">
@@ -36,7 +36,7 @@
                     <p>
                         Lastly we offer a Cardano Stake Pool so that our users may delegate voting rights to our online servers allowing them to stake offline.
                     </p>
-                    <a class="" href="{{ .Site.BaseURL }}cardano/">Learn more</a>
+                    <a class="" href="/cardano/">Learn more</a>
                 </div>
             </div>
         </div>

--- a/fractalide-hugo-theme/layouts/partials/stack.html
+++ b/fractalide-hugo-theme/layouts/partials/stack.html
@@ -5,7 +5,7 @@
                 <div class="row">
                     <div class="col-md-offset-2 col-md-8">
                         <div class="text-center">
-                            <img src="{{ .Site.BaseURL }}img/stack-min.png" width="121px" />
+                            <img src="/img/stack-min.png" width="121px" />
                             <h1 class="section_heading_white">A New Browser Connected to a Smart Contract App Store</h1>
                             <p class="text_white">
                                 Fractalide provides a new browser for smart contracts and cryptocurrencies.  The browser, Hyperflow, allows people to execute and develop applications found in a connected app marketplace called Fractalmarket. We also offer Development Services, Technical Analysis and provide a Cardano Stake Pool.

--- a/fractalide-hugo-theme/layouts/partials/widgets/search.html
+++ b/fractalide-hugo-theme/layouts/partials/widgets/search.html
@@ -5,7 +5,7 @@
     <form action="//google.com/search" method="get" accept-charset="UTF-8" role="search">
         <div class="input-group">
             <input type="search" name="q" class="form-control" placeholder="{{ i18n "searchTitle" }}">
-            <input type="hidden" name="sitesearch" value="{{ .Site.BaseURL }}">
+            <input type="hidden" name="sitesearch" value="/">
             <span class="input-group-btn">
                 <button type="submit" class="btn btn-blue">
                     <img src="{{ $.Site.BaseURL }}img/blog-min/icon-search-min.png" width="20px">


### PR DESCRIPTION
The {{ .Site.BaseURL }} is used in several places, which creates more
work when moving between hugo and styx. In some places the URLs are
broken because BaseURL has no trailing slash.

Solution: Replace all {{ .Site.BaseURL }} with /. Do related cleanup.