### PR TITLE
Problem: new-site/preview.sh breaks on 0 arguments

### DIFF
--- a/fractalide-hugo-theme/exampleSite/preview.sh
+++ b/fractalide-hugo-theme/exampleSite/preview.sh
@@ -2,4 +2,4 @@
 
 cd "${BASH_SOURCE[0]%/*}"
 
-exec nix-shell --run "xargs -0 hugo serve" < <(printf "%s\0" "$@")
+exec nix-shell --run "xargs -0 hugo serve" < <( (( $# > 0 )) && printf "%s\0" "$@")

--- a/new-site/preview.sh
+++ b/new-site/preview.sh
@@ -2,4 +2,4 @@
 
 cd "${BASH_SOURCE[0]%/*}"
 
-exec nix-shell --run "xargs -0 styx preview" < <(printf "%s\0" "$@")
+exec nix-shell --run "xargs -0 styx preview" < <( (( $# > 0 )) && printf "%s\0" "$@")


### PR DESCRIPTION
`styx` gets an empty string argument and complains.

I was always running it with a `--port` argument, so I didn't notice.

Solution: Test for arguments before running printf.

`hugo` ignores the empty argument, but fix both for consistency.