### PR TITLE
Problem: no atom feed

### DIFF
--- a/new-site/site.nix
+++ b/new-site/site.nix
@@ -152,6 +152,13 @@ rec {
       layout      = templates.layout;
     };
 
+    feed = {
+      path     = "/blog/feed.xml";
+      template = templates.feed.atom;
+      items    = lib.take 10 blog.list;
+      layout   = lib.id;
+    };
+
     err_404 = rec {
       path     = "/404.html";
       title    = "404 Page Not Found";


### PR DESCRIPTION
Solution: Define atom feed for blog.

Naming the page attribute `feed` automatically adds a `rel="alternate"`
link to head.