### PR TITLE
Problem: no /documentation/*

### DIFF
--- a/new-site/site.nix
+++ b/new-site/site.nix
@@ -82,6 +82,14 @@ rec {
     };
   };
 
+  doc-index-content = pkgs.runCommand "doc-index" {
+    buildInputs = [ pkgs.styx ];
+    allowSubstitutes = false;
+    src = fractalide-src;
+  } ''
+    asciidoctor -b xhtml5 -s -a showtitle -o- $src/doc/index.adoc > $out
+  '';
+
   doc-pages = builtins.listToAttrs (builtins.map (docpage:
     let subpath = builtins.replaceStrings [ "_" ] [ "/" ] docpage.fileData.basename; in
     {
@@ -91,7 +99,9 @@ rec {
         template = templates.block-page.full;
         layout = templates.layout;
         blocks = [ content ];
-        content = docpage;
+        content = if docpage.fileData.basename == "doc_index" then {
+          content = builtins.readFile doc-index-content;
+        } else docpage;
       };
     } 
   ) data.documentation);

--- a/new-site/site.nix
+++ b/new-site/site.nix
@@ -8,8 +8,8 @@
 , pkgs ? import ./nixpkgs.nix {}
 , fractalide-src ? pkgs.fetchFromGitHub {
     owner = "fractalide"; repo = "fractalide";
-    rev = "085888b4db13ccf01bfee5993318c6cc912696d8";
-    sha256 = "145bccp42mjzxabq8syl9bw56qgbng2xdx6lp3l95cgbg3mb4dih";
+    rev = "27395e8ecc781a01da58c39a6eea01981940b334";
+    sha256 = "0j6cbpnwj84dc4hbnv74av7zdzpw22zbp5xsby9b6cr3anwx1cy6";
   }
 , changelog ? builtins.fromJSON (builtins.readFile "${fractalide-src}/CHANGELOG.json")
 }:


### PR DESCRIPTION
Solution: Render /documentation/* from fractalide/fractalide source.

This does not yet close #43. There is nothing at `/documentation/index.html` for the nav header to point at. The documentation starts at the tautological `/documentation/doc/index.html`.