### PR TITLE
Problem: nav header does not point to documentation

### DIFF
--- a/new-site/data/nav.nix
+++ b/new-site/data/nav.nix
@@ -14,7 +14,7 @@
     name = "Resources";
     children = [
       { name = "Research"; url = "/research/"; }
-      { name = "Documentation"; url = "/documentation/"; }
+      { name = "Documentation"; url = "/fractalide/doc/"; }
       { name = "GitHub"; url = "https://github.com/fractalide/"; }
       { name = "FAQs"; url = "/faqs/"; }
     ];

--- a/new-site/site.nix
+++ b/new-site/site.nix
@@ -95,7 +95,7 @@ rec {
     {
       name = docpage.fileData.basename;
       value = rec {
-        path = "/documentation/${subpath}.html";
+        path = "/fractalide/${subpath}.html";
         template = templates.block-page.full;
         layout = templates.layout;
         blocks = [ content ];


### PR DESCRIPTION
Also, `documentation/doc` is a tautology. I guess so is
`fractalide.com/fractalide`, but it somehow doesn't look as bad.

Solution: Point documentation menu item at `/fractalide/doc/`.

Move documentation there.