### PR TITLE
Problem: The /documentation/* pages are terribly wide

### DIFF
--- a/new-site/data/nav.nix
+++ b/new-site/data/nav.nix
@@ -14,7 +14,7 @@
     name = "Resources";
     children = [
       { name = "Research"; url = "/research/"; }
-      { name = "Documentation"; url = "/fractalide/doc/"; }
+      { name = "Documentation"; url = "/documentation/"; }
       { name = "GitHub"; url = "https://github.com/fractalide/"; }
       { name = "FAQs"; url = "/faqs/"; }
     ];

--- a/new-site/site.nix
+++ b/new-site/site.nix
@@ -14,19 +14,6 @@
 , changelog ? builtins.fromJSON (builtins.readFile "${fractalide-src}/CHANGELOG.json")
 }:
 
-let
-  fractalide-docs = pkgs.stdenvNoCC.mkDerivation {
-    name = "fractalide-docs";
-    src = fractalide-src;
-    phases = "unpackPhase installPhase";
-    buildInputs = [ pkgs.findutils pkgs.gnused ];
-    installPhase = ''
-      mkdir $out
-      find . -name '*.adoc' -exec bash -c 'outname=$(echo "$1" | sed -e "s,^./,," -e s,/,_,g); exec cp "$1" "$out/$outname"' cp {} ';'
-    '';
-  };
-in
-  
 rec {
 
   /* Importing styx library
@@ -77,34 +64,7 @@ rec {
     site-partials = lib.loadDir { dir = ./data/site-partials; inherit env; asAttrs = true; };
     team = lib.loadDir { dir = ./data/team; };
     faqs = import ./data/faqs.nix;
-    documentation = lib.loadDir {
-      dir = fractalide-docs;
-    };
   };
-
-  doc-index-content = pkgs.runCommand "doc-index" {
-    buildInputs = [ pkgs.styx ];
-    allowSubstitutes = false;
-    src = fractalide-src;
-  } ''
-    asciidoctor -b xhtml5 -s -a showtitle -o- $src/doc/index.adoc > $out
-  '';
-
-  doc-pages = builtins.listToAttrs (builtins.map (docpage:
-    let subpath = builtins.replaceStrings [ "_" ] [ "/" ] docpage.fileData.basename; in
-    {
-      name = docpage.fileData.basename;
-      value = rec {
-        path = "/fractalide/${subpath}.html";
-        template = templates.container;
-        layout = templates.layout;
-        content = if docpage.fileData.basename == "doc_index" then
-          builtins.readFile doc-index-content
-        else docpage.content;
-      };
-    } 
-  ) data.documentation);
-
 
 /*-----------------------------------------------------------------------------
    Pages
@@ -119,6 +79,22 @@ rec {
       layout   = templates.layout;
       blocks   = [ content ];
       content  = lib.loadFile { file = ./content/contact.md; env = {}; };
+    };
+
+    documentation = rec {
+      title    = "Documentation";
+      path     = "/documentation/index.html";
+      template = templates.container;
+      layout   = templates.layout;
+      content  = builtins.readFile (
+        pkgs.runCommand "doc-index" {
+          buildInputs = [ pkgs.styx ];
+          allowSubstitutes = false;
+          src = fractalide-src;
+        } ''
+          asciidoctor -b xhtml5 -s -a showtitle -o- $src/doc/index.adoc > $out
+        ''
+      );
     };
 
     index = rec {
@@ -237,7 +213,7 @@ rec {
         inherit lib title;
       }; };
     };
-  } // doc-pages;
+  };
 
 
 /*-----------------------------------------------------------------------------

--- a/new-site/site.nix
+++ b/new-site/site.nix
@@ -96,12 +96,11 @@ rec {
       name = docpage.fileData.basename;
       value = rec {
         path = "/fractalide/${subpath}.html";
-        template = templates.block-page.full;
+        template = templates.container;
         layout = templates.layout;
-        blocks = [ content ];
-        content = if docpage.fileData.basename == "doc_index" then {
-          content = builtins.readFile doc-index-content;
-        } else docpage;
+        content = if docpage.fileData.basename == "doc_index" then
+          builtins.readFile doc-index-content
+        else docpage.content;
       };
     } 
   ) data.documentation);

--- a/new-site/themes/fractalide/templates/container.nix
+++ b/new-site/themes/fractalide/templates/container.nix
@@ -1,0 +1,14 @@
+env:
+
+let template = { lib, templates, ... }:
+  lib.normalTemplate (page: ''
+    <div class="container">
+    ${page.content}
+    </div> <!-- container -->
+  '');
+
+in with env.lib; documentedTemplate {
+  description = "Template that wraps our usual `container` div around the content.";
+
+  inherit env template;
+}


### PR DESCRIPTION
Solution: Create `container` template, apply to documentation.

The `container` template wraps everything in a `class="container"` div
element.

Closes #82