### PR TITLE
Problem: /faqs/ has no email at the bottom

### DIFF
--- a/new-site/content/faqs/footer.md
+++ b/new-site/content/faqs/footer.md
@@ -5,7 +5,7 @@
                         <div class="text-center">
                             <h1 class="section_heading_white">Got another question?</h1>
                             <p class="text_white">
-                                Contact us at ${faqs.email}
+                                Contact us at {{ faqs.email }}
                             </p>
                         </div>
                     </div>

--- a/new-site/data/faqs.nix
+++ b/new-site/data/faqs.nix
@@ -9,5 +9,6 @@
 "answer" = "No, Fractalide is an application framework that locally executes applications that are programmed to interface with smart contracts, you might or might not have written, that are already deployed to the Cardano blockchain.";
 }
 ];
+  email = "info@fractalide.com";
 }
 


### PR DESCRIPTION
It is just an unparsed (incorrectly formatted) call to faqs.email
which does not exist.

Solution: Add info@fractalide.com to data/faqs and use the correct syntax.

I don't know if this is the correct address. See #89 .