### PR TITLE
Problem: main sections don't have ids

### DIFF
--- a/themes/fractalide/templates/page/full.nix
+++ b/themes/fractalide/templates/page/full.nix
@@ -2,7 +2,7 @@ env:
 
 let template = { lib, templates, ... }:
   lib.normalTemplate (page: ''
-    <section${lib.optionalString (page ? section) (" " + ''"${page.section}"'')}>
+    <section${lib.optionalString (page ? section) (" id=" + ''"${page.section}"'')}>
       ${lib.optionalString (page ? title) ''
         <div class="header_gradient"> <!-- title -->
           <div class="container">

--- a/themes/fractalide/templates/page/sections.nix
+++ b/themes/fractalide/templates/page/sections.nix
@@ -3,7 +3,7 @@ env:
 let template = { lib, templates, ... }:
   lib.normalTemplate (page: ''
     ${lib.optionalString (page ? title) ''
-      <section${lib.optionalString (page ? section) " " + ''"${page.section}"''}>
+      <section${lib.optionalString (page ? section) " id=" + ''"${page.section}"''}>
         <div class="header_background"> <!-- title -->
          <div class="header_content_stack">
           <div class="container">


### PR DESCRIPTION
Expected: `<section id="about_us">`

Actual: `<section "about_us">`

Solution: Add the 'id='.

This probably broke all kinds of CSS.