### PR TITLE
Problem: mail address at faqs bottom is not a mailto: link

### DIFF
--- a/content/faqs/footer.md
+++ b/content/faqs/footer.md
@@ -5,7 +5,7 @@
                         <div class="text-center">
                             <h1 class="section_heading_white">Got another question?</h1>
                             <p class="text_white">
-                                Contact us at {{ faqs.email }}
+                                Contact us at <a href="mailto:{{faqs.email}}">{{faqs.email}}</a>.
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
Solution: Add the explicit HTML.

Major side notes:

Hypothetically, this should be enough:

    <{{ faqs.email }}>

But it turns out, multimarkdown won't parse markdown inside explicit
HTML elements. Maybe we should make styx send `--process-html` to
multimarkdown.

So I tried an inline call to markdownToHtml, `{{ lib.markdownToHtml faqs.email }}`.

Bonus: mmd obfuscates mail addresses by html-entityfying
the whole thing, some in decimal, some in hexadecimal:

    Contact us at <p><a href="&#109;&#97;&#105;&#108;&#x74;&#111;&#x3a;&#x69;&#x6e;&#102;&#x6f;&#x40;&#x66;&#x72;&#97;&#99;&#116;&#97;&#108;&#105;&#100;&#101;&#x2e;&#99;&#111;&#x6d;">&#x69;&#x6e;&#x66;&#111;&#x40;&#x66;&#114;&#97;&#99;&#x74;&#97;&#x6c;&#x69;&#x64;&#101;&#x2e;&#99;&#x6f;&#x6d;</a></p>

But as you see, it invariably adds a `<p/>` element around the converted
text. So I figured let's just feed the whole paragraph to markdown.

Now we had a paragraph that didn't have the `text_white` attribute,
inside the paragraph that did.

Does multimarkdown allow adding the attribute to a paragraph? No, that
would be too much markup, and goes against markdown philosophy. Only
images and links can add arbitrary attributes.

Final try: Can I use inline asciidoc instead? asciidoc allows all kinds
of markup and control over aspects of the generated text!

    {{ lib.asciidocToHtml ''
      [role=text_white]
      Contact us at ${faqs.email}.
    '' }}

    <div class="paragraph text_white">
    <p>Contact us at <a href="mailto:info@fractalide.com">info@fractalide.com</a>.</p>
    </div>

Ugh. NO.

Explicit HTML it is.

Closes #92