### PR TITLE
Problem: CNAME is not being created

### DIFF
--- a/conf.nix
+++ b/conf.nix
@@ -1,9 +1,10 @@
 { lib }:
-{
+rec {
   /* URL of the site, must be set to the url of the domain the site will be deployed.
      Should not end with a '/'.
   */
-  siteUrl = "http://fractalide.com";
+  domain = "fractalide.com";
+  siteUrl = "http://${domain}";
 
   /* Theme specific settings
      it is possible to override any of the used themes configuration in this set.

--- a/site.nix
+++ b/site.nix
@@ -252,6 +252,10 @@ rec {
 
   /* Generating the site
   */
-  site = lib.mkSite { inherit files pageList; };
-
+  site = lib.mkSite {
+    inherit files pageList;
+    postGen = ''
+      echo "${conf.domain}" > $out/CNAME
+    '';
+  };
 }


### PR DESCRIPTION
This happened when we replaced the old site with new-site.

Solution: Bring back CNAME in mkSite postGen.

Now `result` and `gh-pages` are identical, apart from the latest update with the mailto thing.