### PR TITLE
Problem: cardano-stake-pool link on home page is broken

### DIFF
--- a/data/site-partials/main.md
+++ b/data/site-partials/main.md
@@ -36,7 +36,7 @@
                     <p>
                         A way to help fund core Fractalide software. A Cardano stake pool allows users to stake offline. All profit goes towards Fractalide development. 
                     </p>
-                    <a class="" href="/cardano/">Learn more</a>
+                    <a class="" href="/cardano-stake-pool/">Learn more</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Solution: it pointed to /cardano/ it should point to /cardano-stake-pool