### PR TITLE
Problem: contact details not present at bottom of pages

### DIFF
--- a/data/site-partials/signup.md
+++ b/data/site-partials/signup.md
@@ -8,6 +8,7 @@
                             <h1 class="section_heading_white">Sign up for early access</h1>
                             <p class="text_white">
                                 You will get the latest news about Fractalide.
+                                <br>Feel free to contact us at <a href="mailto:info@fractalide.com">info@fractalide.com</a>.<br>We will never share your contact details.
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
Solution: add info@fractalide.com now that the email address is
working. Also mention we will never share peoples' info