### PR TITLE
 Problem: Nowhere to add live data from the baker

### DIFF
--- a/content/stake-pool/tezos-xtz.md
+++ b/content/stake-pool/tezos-xtz.md
@@ -14,7 +14,7 @@
             <h2 class="sub_heading_blue">Delegation address</h2>
             <div class="row white_box">
                 <div class="col-lg-8 col-xs-offset-1 col-xs-10">
-                    <span id="delegationAddress">OUR-XTZ-STAKEPOOL-IS-NOT-READY-YET<span>
+                    <span id="delegationAddress">{{ address }}<span>
                 </div>
                 <div class="col-lg-4 col-xs-offset-1 col-xs-10">
                     <a class="copy" href="#" onclick="javascript:copyToClipboard('delegationAddress',event);">

--- a/live.sh
+++ b/live.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 cd "${BASH_SOURCE[0]%/*}"
 
-exec nix-shell --run "xargs -0 styx live" < <( (( $# > 0 )) && printf "%s\0" "$@")
+styx=$(nix-build --no-out-link ./nixpkgs.nix -A styx)
+exec $styx/bin/styx live "$@"

--- a/live.sh
+++ b/live.sh
@@ -5,4 +5,4 @@ set -euo pipefail
 cd "${BASH_SOURCE[0]%/*}"
 
 styx=$(nix-build --no-out-link ./nixpkgs.nix -A styx)
-exec $styx/bin/styx live "$@"
+exec $styx/bin/styx live -I "fractalide-com-config=$PWD/test-data" "$@"

--- a/preview.sh
+++ b/preview.sh
@@ -5,4 +5,4 @@ set -euo pipefail
 cd "${BASH_SOURCE[0]%/*}"
 
 styx=$(nix-build --no-out-link ./nixpkgs.nix -A styx)
-exec $styx/bin/styx preview "$@"
+exec $styx/bin/styx preview -I "fractalide-com-config=$PWD/test-data" "$@"

--- a/preview.sh
+++ b/preview.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 cd "${BASH_SOURCE[0]%/*}"
 
-exec nix-shell --run "xargs -0 styx preview" < <( (( $# > 0 )) && printf "%s\0" "$@")
+styx=$(nix-build --no-out-link ./nixpkgs.nix -A styx)
+exec $styx/bin/styx preview "$@"

--- a/site.nix
+++ b/site.nix
@@ -12,6 +12,7 @@
     sha256 = "04yfzjjskimrjds4jk0z9s18873d939l3sc1sjm0r1m7cs280ddl";
   }
 , changelog ? builtins.fromJSON (builtins.readFile "${fractalide-src}/CHANGELOG.json")
+, liveConf ? pkgs.callPackage <fractalide-com-config> {}
 }:
 
 rec {
@@ -181,7 +182,10 @@ rec {
       path     = "/stake-pool/tezos-xtz/index.html";
       template = templates.page.full;
       layout   = templates.layout;
-      content  = (lib.loadFile { file = ./content/stake-pool/tezos-xtz.md; }).content;
+      content  = (lib.loadFile {
+        file = ./content/stake-pool/tezos-xtz.md;
+        env = { inherit (liveConf.stakepool.xtz) address data; };
+      }).content;
       extraContent = site-partials.signup.content;
     };
 

--- a/test-data/default.nix
+++ b/test-data/default.nix
@@ -1,0 +1,9 @@
+{
+}:
+
+{
+  stakepool.xtz = {
+    data = builtins.fromJSON (builtins.readFile ./staker_data.json);
+    address = "tz11111Not1A1Real1Address11111111111";
+  };
+}


### PR DESCRIPTION


Solution: Look in <fractalide-com-config>.

 - Make the preview and live scripts point it to the test data.
 - Make use of the configured delegation address on the Tezos Stakepool page.