### PR TITLE
Problem: backerei's data output not present

### DIFF
--- a/test-data/.backerei.json
+++ b/test-data/.backerei.json
@@ -1,0 +1,1907 @@
+{
+    "payoutsByCycle": {
+        "12": {
+            "delegators": {},
+            "estimatedBakerRewards": {
+                "bondRewards": "2000000",
+                "feeRewards": "0",
+                "looseRewards": "0",
+                "totalRewards": "2000000"
+            },
+            "estimatedTotalRewards": "2000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "2000000",
+                "feeRewards": "0",
+                "looseRewards": "0",
+                "totalRewards": "2000000"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "0",
+                "paid": "2000000",
+                "realized": "2000000",
+                "realizedDifference": "0"
+            },
+            "stakingBalance": "10009950000",
+            "stolenBlocks": []
+        },
+        "13": {
+            "delegators": {},
+            "estimatedBakerRewards": {
+                "bondRewards": "6000000",
+                "feeRewards": "0",
+                "looseRewards": "0",
+                "totalRewards": "6000000"
+            },
+            "estimatedTotalRewards": "6000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "6000000",
+                "feeRewards": "0",
+                "looseRewards": "0",
+                "totalRewards": "6000000"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "0",
+                "paid": "6000000",
+                "realized": "5000000",
+                "realizedDifference": "-1000000"
+            },
+            "stakingBalance": "10009950000",
+            "stolenBlocks": []
+        },
+        "14": {
+            "delegators": {
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90006000000",
+                    "estimatedRewards": "108529925",
+                    "finalRewards": "108529925"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "13411193",
+                "feeRewards": "12058880",
+                "looseRewards": "2",
+                "totalRewards": "25470075"
+            },
+            "estimatedTotalRewards": "134000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "13411193",
+                "feeRewards": "12058880",
+                "looseRewards": "2",
+                "totalRewards": "25470075"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "0",
+                "paid": "134000000",
+                "realized": "133000000",
+                "realizedDifference": "-1000000"
+            },
+            "stakingBalance": "100015950000",
+            "stolenBlocks": []
+        },
+        "15": {
+            "delegators": {
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90004000000",
+                    "estimatedRewards": "71738897",
+                    "finalRewards": "71739475"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "44290113",
+                "feeRewards": "7970988",
+                "looseRewards": "2",
+                "totalRewards": "52261103"
+            },
+            "estimatedTotalRewards": "124000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "44290471",
+                "feeRewards": "7971052",
+                "looseRewards": "2",
+                "totalRewards": "52261525"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-1000",
+                "paid": "124001000",
+                "realized": "118667666",
+                "realizedDifference": "-5333334"
+            },
+            "stakingBalance": "140013950000",
+            "stolenBlocks": []
+        },
+        "16": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "772",
+                    "finalRewards": "772"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "780217858",
+                    "finalRewards": "780218615"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "69525189",
+                    "finalRewards": "69525256"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "85840199",
+                "feeRewards": "94415980",
+                "looseRewards": "2",
+                "totalRewards": "180256181"
+            },
+            "estimatedTotalRewards": "1030000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "85840283",
+                "feeRewards": "94416071",
+                "looseRewards": "3",
+                "totalRewards": "180256357"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-1000",
+                "paid": "1030001000",
+                "realized": "1016167666",
+                "realizedDifference": "-13833334"
+            },
+            "stakingBalance": "1200023400000",
+            "stolenBlocks": [
+                {
+                    "fees": "0",
+                    "hash": "BLXJNsYM82tEkZDsGzrmAeGmF1TNf2ppeh7SbWmgTBTzTGEEMrW",
+                    "level": 67269,
+                    "priority": 1,
+                    "reward": "16000000"
+                }
+            ]
+        },
+        "17": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "881",
+                    "finalRewards": "882"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "890811846",
+                    "finalRewards": "890852513"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "79380216",
+                    "finalRewards": "79383839"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "98007839",
+                "feeRewards": "107799216",
+                "looseRewards": "2",
+                "totalRewards": "205807057"
+            },
+            "estimatedTotalRewards": "1176000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "98012314",
+                "feeRewards": "107804136",
+                "looseRewards": "3",
+                "totalRewards": "205816453"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-53687",
+                "paid": "1176053687",
+                "realized": "1141053687",
+                "realizedDifference": "-35000000"
+            },
+            "stakingBalance": "1200023400000",
+            "stolenBlocks": []
+        },
+        "18": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "904",
+                    "finalRewards": "904"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "913536638",
+                    "finalRewards": "913538910"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "81405221",
+                    "finalRewards": "81405424"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "100508039",
+                "feeRewards": "110549196",
+                "looseRewards": "2",
+                "totalRewards": "211057237"
+            },
+            "estimatedTotalRewards": "1206000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "100508289",
+                "feeRewards": "110549471",
+                "looseRewards": "2",
+                "totalRewards": "211057762"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-3000",
+                "paid": "1206003000",
+                "realized": "1186003000",
+                "realizedDifference": "-20000000"
+            },
+            "stakingBalance": "1200023400000",
+            "stolenBlocks": []
+        },
+        "19": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "835",
+                    "finalRewards": "835"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "843847275",
+                    "finalRewards": "843849549"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "75195204",
+                    "finalRewards": "75195407"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "92840759",
+                "feeRewards": "102115924",
+                "looseRewards": "3",
+                "totalRewards": "194956686"
+            },
+            "estimatedTotalRewards": "1114000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "92841009",
+                "feeRewards": "102116199",
+                "looseRewards": "2",
+                "totalRewards": "194957210"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-3001",
+                "paid": "1114003001",
+                "realized": "1109003001",
+                "realizedDifference": "-5000000"
+            },
+            "stakingBalance": "1200023400000",
+            "stolenBlocks": [
+                {
+                    "fees": "1000",
+                    "hash": "BLXizXSrNh8LfBgi6sPkBUFUZj7eJNzvmrQsHQ6Zgt4fPjc8LHV",
+                    "level": 79931,
+                    "priority": 1,
+                    "reward": "16000000"
+                }
+            ]
+        },
+        "20": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "836",
+                    "finalRewards": "836"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "845362262",
+                    "finalRewards": "845364610"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "75330205",
+                    "finalRewards": "75330414"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "93007439",
+                "feeRewards": "102299256",
+                "looseRewards": "2",
+                "totalRewards": "195306697"
+            },
+            "estimatedTotalRewards": "1116000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "93007698",
+                "feeRewards": "102299540",
+                "looseRewards": "2",
+                "totalRewards": "195307240"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-3100",
+                "paid": "1116003100",
+                "realized": "1103003100",
+                "realizedDifference": "-13000000"
+            },
+            "stakingBalance": "1200023400000",
+            "stolenBlocks": []
+        },
+        "21": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "785",
+                    "finalRewards": "785"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "793852733",
+                    "finalRewards": "793852733"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "70740192",
+                    "finalRewards": "70740192"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "87340319",
+                "feeRewards": "96065968",
+                "looseRewards": "3",
+                "totalRewards": "183406290"
+            },
+            "estimatedTotalRewards": "1048000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "87340319",
+                "feeRewards": "96065968",
+                "looseRewards": "3",
+                "totalRewards": "183406290"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "0",
+                "paid": "1048000000",
+                "realized": "1028000000",
+                "realizedDifference": "-20000000"
+            },
+            "stakingBalance": "1200023400000",
+            "stolenBlocks": []
+        },
+        "22": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "776",
+                    "finalRewards": "777"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "784762816",
+                    "finalRewards": "784804487"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "69930190",
+                    "finalRewards": "69933903"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "86340239",
+                "feeRewards": "94965976",
+                "looseRewards": "3",
+                "totalRewards": "181306218"
+            },
+            "estimatedTotalRewards": "1036000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "86344824",
+                "feeRewards": "94971018",
+                "looseRewards": "2",
+                "totalRewards": "181315844"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-55011",
+                "paid": "1036055011",
+                "realized": "1053388343",
+                "realizedDifference": "17333332"
+            },
+            "stakingBalance": "1200023400000",
+            "stolenBlocks": [
+                {
+                    "fees": "0",
+                    "hash": "BMZQwczKUS1qrnFEx4bprzLhAH9L3b6nfnjsBGM6dSLktY9tmhB",
+                    "level": 90124,
+                    "priority": 1,
+                    "reward": "16000000"
+                },
+                {
+                    "fees": "1000",
+                    "hash": "BMMLDuWJhkMmewLmYPAtCiEZPspveeCu7en91XiTevrH7hNKGLr",
+                    "level": 92864,
+                    "priority": 1,
+                    "reward": "16000000"
+                }
+            ]
+        },
+        "23": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "823",
+                    "finalRewards": "823"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "831727386",
+                    "finalRewards": "831729681"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "74115201",
+                    "finalRewards": "74115406"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "91507320",
+                "feeRewards": "100649267",
+                "looseRewards": "3",
+                "totalRewards": "192156590"
+            },
+            "estimatedTotalRewards": "1098000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "91507573",
+                "feeRewards": "100649545",
+                "looseRewards": "2",
+                "totalRewards": "192157120"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-3030",
+                "paid": "1098003030",
+                "realized": "1100003030",
+                "realizedDifference": "2000000"
+            },
+            "stakingBalance": "1200023401000",
+            "stolenBlocks": [
+                {
+                    "fees": "1000",
+                    "hash": "BLyu3VmKmn9w3xGVQwCj9FEdSHyfhDDPWLvWs8arPS34wpzeZhw",
+                    "level": 97716,
+                    "priority": 1,
+                    "reward": "16000000"
+                }
+            ]
+        },
+        "24": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "718",
+                    "finalRewards": "718"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "725678355",
+                    "finalRewards": "725679870"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "64665175",
+                    "finalRewards": "64665310"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "79839722",
+                "feeRewards": "87816027",
+                "looseRewards": "3",
+                "totalRewards": "167655752"
+            },
+            "estimatedTotalRewards": "958000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "79839888",
+                "feeRewards": "87816211",
+                "looseRewards": "3",
+                "totalRewards": "167656102"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-2000",
+                "paid": "958002000",
+                "realized": "973668666",
+                "realizedDifference": "15666666"
+            },
+            "stakingBalance": "1200023403000",
+            "stolenBlocks": [
+                {
+                    "fees": "0",
+                    "hash": "BKoMAaSAwZtEJT24YFq371128H33kR5s3R4zaJTzFpMzoyrA2j8",
+                    "level": 99372,
+                    "priority": 1,
+                    "reward": "16000000"
+                },
+                {
+                    "fees": "1000",
+                    "hash": "BM9J58X1bcR3thndV2mwyYneiaEz7R1SZnEkuBnyb8oaW6C1LHJ",
+                    "level": 99526,
+                    "priority": 1,
+                    "reward": "16000000"
+                }
+            ]
+        },
+        "25": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "808",
+                    "finalRewards": "808"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "816576126",
+                    "finalRewards": "816576126"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "72765073",
+                    "finalRewards": "72765073"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "89842213",
+                "feeRewards": "98815778",
+                "looseRewards": "2",
+                "totalRewards": "188657993"
+            },
+            "estimatedTotalRewards": "1078000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "89842213",
+                "feeRewards": "98815778",
+                "looseRewards": "2",
+                "totalRewards": "188657993"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "0",
+                "paid": "1078000000",
+                "realized": "1083000000",
+                "realizedDifference": "5000000"
+            },
+            "stakingBalance": "1200025456687",
+            "stolenBlocks": [
+                {
+                    "fees": "0",
+                    "hash": "BMdxDGhtZFvs1isGKGEB6qQRs2RZHEdiPLBj3AS8vb84vC8RBqx",
+                    "level": 102537,
+                    "priority": 1,
+                    "reward": "16000000"
+                }
+            ]
+        },
+        "26": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "689",
+                    "finalRewards": "689"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "696889520",
+                    "finalRewards": "696891801"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "62099803",
+                    "finalRewards": "62100006"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "76677762",
+                "feeRewards": "84332223",
+                "looseRewards": "3",
+                "totalRewards": "161009988"
+            },
+            "estimatedTotalRewards": "920000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "76678013",
+                "feeRewards": "84332499",
+                "looseRewards": "4",
+                "totalRewards": "161010516"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-3012",
+                "paid": "920003012",
+                "realized": "917003012",
+                "realizedDifference": "-3000000"
+            },
+            "stakingBalance": "1200030461688",
+            "stolenBlocks": []
+        },
+        "27": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "782",
+                    "finalRewards": "782"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "790748949",
+                    "finalRewards": "790749798"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "70463614",
+                    "finalRewards": "70463690"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "87096280",
+                "feeRewards": "95690371",
+                "looseRewards": "4",
+                "totalRewards": "182786655"
+            },
+            "estimatedTotalRewards": "1044000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "87096374",
+                "feeRewards": "95690474",
+                "looseRewards": "2",
+                "totalRewards": "182786850"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-1120",
+                "paid": "1044001120",
+                "realized": "1036001120",
+                "realizedDifference": "-8000000"
+            },
+            "stakingBalance": "1200135414788",
+            "stolenBlocks": []
+        },
+        "28": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "806",
+                    "finalRewards": "806"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "814905889",
+                    "finalRewards": "814907404"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "72616238",
+                    "finalRewards": "72616373"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "89863405",
+                "feeRewards": "98613659",
+                "looseRewards": "3",
+                "totalRewards": "188477067"
+            },
+            "estimatedTotalRewards": "1076000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "89863572",
+                "feeRewards": "98613842",
+                "looseRewards": "3",
+                "totalRewards": "188477417"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-2000",
+                "paid": "1076002000",
+                "realized": "1056954380",
+                "realizedDifference": "-19047620"
+            },
+            "stakingBalance": "1200254081454",
+            "stolenBlocks": []
+        },
+        "29": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "779",
+                    "finalRewards": "779"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "786975070",
+                    "finalRewards": "786976585"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "70127324",
+                    "finalRewards": "70127459"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "87663140",
+                "feeRewards": "95233685",
+                "looseRewards": "2",
+                "totalRewards": "182896827"
+            },
+            "estimatedTotalRewards": "1040000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "87663309",
+                "feeRewards": "95233869",
+                "looseRewards": "2",
+                "totalRewards": "182897180"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-2003",
+                "paid": "1040002003",
+                "realized": "1037002003",
+                "realizedDifference": "-3000000"
+            },
+            "stakingBalance": "1201270303131",
+            "stolenBlocks": [
+                {
+                    "fees": "0",
+                    "hash": "BLoSeLE5YULJmPZt2xA7UxaaCugW8yh84myxfFkAbsHn3TxW4Ao",
+                    "level": 122310,
+                    "priority": 1,
+                    "reward": "16000000"
+                }
+            ]
+        },
+        "30": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "733",
+                    "finalRewards": "733"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "740868963",
+                    "finalRewards": "740868963"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "66018810",
+                    "finalRewards": "66018810"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "83457213",
+                "feeRewards": "89654278",
+                "looseRewards": "3",
+                "totalRewards": "173111494"
+            },
+            "estimatedTotalRewards": "980000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "83457213",
+                "feeRewards": "89654278",
+                "looseRewards": "3",
+                "totalRewards": "173111494"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "0",
+                "paid": "980000000",
+                "realized": "960000000",
+                "realizedDifference": "-20000000"
+            },
+            "stakingBalance": "1202411304141",
+            "stolenBlocks": []
+        },
+        "31": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "762",
+                    "finalRewards": "762"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "770348676",
+                    "finalRewards": "770350186"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "68645746",
+                    "finalRewards": "68645881"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "87783126",
+                "feeRewards": "93221687",
+                "looseRewards": "3",
+                "totalRewards": "181004816"
+            },
+            "estimatedTotalRewards": "1020000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "87783299",
+                "feeRewards": "93221870",
+                "looseRewards": "2",
+                "totalRewards": "181005171"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-2000",
+                "paid": "1020002000",
+                "realized": "1001668666",
+                "realizedDifference": "-18333334"
+            },
+            "stakingBalance": "1203597308161",
+            "stolenBlocks": []
+        },
+        "32": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "741",
+                    "finalRewards": "741"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "200000000000",
+                    "estimatedRewards": "148355890",
+                    "finalRewards": "148356019"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "749205001",
+                    "finalRewards": "749205650"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "66761634",
+                    "finalRewards": "66761692"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "94529701",
+                "feeRewards": "107147029",
+                "looseRewards": "4",
+                "totalRewards": "201676734"
+            },
+            "estimatedTotalRewards": "1166000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "94529783",
+                "feeRewards": "107147122",
+                "looseRewards": "3",
+                "totalRewards": "201676908"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-1010",
+                "paid": "1166001010",
+                "realized": "1156001010",
+                "realizedDifference": "-10000000"
+            },
+            "stakingBalance": "1414706208161",
+            "stolenBlocks": []
+        },
+        "33": {
+            "delegators": {
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "693",
+                    "finalRewards": "693"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "277511737",
+                    "finalRewards": "277511961"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "700724388",
+                    "finalRewards": "700724952"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "62441528",
+                    "finalRewards": "62441578"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "109690724",
+                "feeRewards": "115630927",
+                "looseRewards": "3",
+                "totalRewards": "225321654"
+            },
+            "estimatedTotalRewards": "1266000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "109690812",
+                "feeRewards": "115631020",
+                "looseRewards": "4",
+                "totalRewards": "225321836"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-1020",
+                "paid": "1266001020",
+                "realized": "1278001020",
+                "realizedDifference": "12000000"
+            },
+            "stakingBalance": "1642308911173",
+            "stolenBlocks": [
+                {
+                    "fees": "0",
+                    "hash": "BLbKtGYsTW4HB4B8CQEq577WAiMGSwY6GdpPHbek24Mc4h67Ups",
+                    "level": 138403,
+                    "priority": 1,
+                    "reward": "16000000"
+                }
+            ]
+        },
+        "34": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "108852942",
+                    "finalRewards": "108852942"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "725",
+                    "finalRewards": "725"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "290274513",
+                    "finalRewards": "290274513"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "732950730",
+                    "finalRewards": "732950730"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "65313216",
+                    "finalRewards": "65313216"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "115564300",
+                "feeRewards": "133043569",
+                "looseRewards": "5",
+                "totalRewards": "248607874"
+            },
+            "estimatedTotalRewards": "1446000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "115564300",
+                "feeRewards": "133043569",
+                "looseRewards": "5",
+                "totalRewards": "248607874"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "0",
+                "paid": "1446000000",
+                "realized": "1428666666",
+                "realizedDifference": "-17333334"
+            },
+            "stakingBalance": "1793336912283",
+            "stolenBlocks": []
+        },
+        "35": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "102770286",
+                    "finalRewards": "102770505"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "685",
+                    "finalRewards": "685"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "274054097",
+                    "finalRewards": "274054681"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "691993756",
+                    "finalRewards": "691995229"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "61663542",
+                    "finalRewards": "61663673"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "109908480",
+                "feeRewards": "125609151",
+                "looseRewards": "3",
+                "totalRewards": "235517634"
+            },
+            "estimatedTotalRewards": "1366000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "109908714",
+                "feeRewards": "125609418",
+                "looseRewards": "4",
+                "totalRewards": "235518136"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-2909",
+                "paid": "1366002909",
+                "realized": "1365002909",
+                "realizedDifference": "-1000000"
+            },
+            "stakingBalance": "1794390247625",
+            "stolenBlocks": [
+                {
+                    "fees": "0",
+                    "hash": "BLzEF3Nct3Jy3v8S6bY5WkgPfxWxWYUT1gVeKmj3v44kvoX1JtH",
+                    "level": 143984,
+                    "priority": 1,
+                    "reward": "16000000"
+                }
+            ]
+        },
+        "36": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "93985472",
+                    "finalRewards": "93986904"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "626",
+                    "finalRewards": "626"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "250627927",
+                    "finalRewards": "250631745"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "632842065",
+                    "finalRewards": "632851704"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "56392536",
+                    "finalRewards": "56393395"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "101279300",
+                "feeRewards": "114872069",
+                "looseRewards": "5",
+                "totalRewards": "216151374"
+            },
+            "estimatedTotalRewards": "1250000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "101280843",
+                "feeRewards": "114873818",
+                "looseRewards": "4",
+                "totalRewards": "216154665"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-19039",
+                "paid": "1250019039",
+                "realized": "1253019039",
+                "realizedDifference": "3000000"
+            },
+            "stakingBalance": "1795490247627",
+            "stolenBlocks": [
+                {
+                    "fees": "5000",
+                    "hash": "BMNHfE5ySWQJsrQpkdpQXbdVu1A3f86yV7D9XVpVFtNkSUTzP6k",
+                    "level": 149979,
+                    "priority": 1,
+                    "reward": "16000000"
+                }
+            ]
+        },
+        "37": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "100547524",
+                    "finalRewards": "100556241"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "670",
+                    "finalRewards": "670"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "268126732",
+                    "finalRewards": "268149978"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "677027004",
+                    "finalRewards": "677085700"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "60329855",
+                    "finalRewards": "60335085"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "109075791",
+                "feeRewards": "122892420",
+                "looseRewards": "4",
+                "totalRewards": "231968215"
+            },
+            "estimatedTotalRewards": "1338000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "109085248",
+                "feeRewards": "122903075",
+                "looseRewards": "3",
+                "totalRewards": "231988326"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-116000",
+                "paid": "1338116000",
+                "realized": "1327782666",
+                "realizedDifference": "-10333334"
+            },
+            "stakingBalance": "1796463916294",
+            "stolenBlocks": []
+        },
+        "38": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "109349023",
+                    "finalRewards": "109350677"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "728",
+                    "finalRewards": "729"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "291597396",
+                    "finalRewards": "291601806"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "736291042",
+                    "finalRewards": "736302178"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "65610872",
+                    "finalRewards": "65611864"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "119501040",
+                "feeRewards": "133649895",
+                "looseRewards": "4",
+                "totalRewards": "253150939"
+            },
+            "estimatedTotalRewards": "1456000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "119502847",
+                "feeRewards": "133651917",
+                "looseRewards": "2",
+                "totalRewards": "253154766"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-22020",
+                "paid": "1456022020",
+                "realized": "1448022020",
+                "realizedDifference": "-8000000"
+            },
+            "stakingBalance": "1797546916294",
+            "stolenBlocks": []
+        },
+        "39": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "96982763",
+                    "finalRewards": "96982763"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "646",
+                    "finalRewards": "646"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "258620701",
+                    "finalRewards": "258620701"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "653024027",
+                    "finalRewards": "653024028"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "58190950",
+                    "finalRewards": "58190951"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "106645456",
+                "feeRewards": "118535454",
+                "looseRewards": "3",
+                "totalRewards": "225180913"
+            },
+            "estimatedTotalRewards": "1292000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "106645456",
+                "feeRewards": "118535454",
+                "looseRewards": "3",
+                "totalRewards": "225180913"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-2",
+                "paid": "1292000002",
+                "realized": "1277000002",
+                "realizedDifference": "-15000000"
+            },
+            "stakingBalance": "1798463918294",
+            "stolenBlocks": []
+        },
+        "40": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "105779387",
+                    "finalRewards": "105779838"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "705",
+                    "finalRewards": "705"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "282078367",
+                    "finalRewards": "282079570"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "712255247",
+                    "finalRewards": "712258283"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "63469043",
+                    "finalRewards": "63469313"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "117130275",
+                "feeRewards": "129286972",
+                "looseRewards": "4",
+                "totalRewards": "246417251"
+            },
+            "estimatedTotalRewards": "1410000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "117130774",
+                "feeRewards": "129287523",
+                "looseRewards": "4",
+                "totalRewards": "246418301"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-6010",
+                "paid": "1410006010",
+                "realized": "1399672676",
+                "realizedDifference": "-10333334"
+            },
+            "stakingBalance": "1799499919314",
+            "stolenBlocks": []
+        },
+        "41": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "100169010",
+                    "finalRewards": "100169835"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "667",
+                    "finalRewards": "667"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "267117360",
+                    "finalRewards": "267119562"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "674478314",
+                    "finalRewards": "674483873"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "60102741",
+                    "finalRewards": "60103237"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "111702116",
+                "feeRewards": "122429788",
+                "looseRewards": "4",
+                "totalRewards": "234131908"
+            },
+            "estimatedTotalRewards": "1336000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "111703036",
+                "feeRewards": "122430797",
+                "looseRewards": "4",
+                "totalRewards": "234133837"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-11011",
+                "paid": "1336011011",
+                "realized": "1325011011",
+                "realizedDifference": "-11000000"
+            },
+            "stakingBalance": "1800556872704",
+            "stolenBlocks": []
+        },
+        "42": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "94566262",
+                    "finalRewards": "94566638"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "630",
+                    "finalRewards": "630"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "252176701",
+                    "finalRewards": "252177702"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "636752758",
+                    "finalRewards": "636755286"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "56741018",
+                    "finalRewards": "56741243"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "106180697",
+                "feeRewards": "115581930",
+                "looseRewards": "4",
+                "totalRewards": "221762631"
+            },
+            "estimatedTotalRewards": "1262000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "106181119",
+                "feeRewards": "115582389",
+                "looseRewards": "3",
+                "totalRewards": "221763511"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-5010",
+                "paid": "1262005010",
+                "realized": "1251005010",
+                "realizedDifference": "-11000000"
+            },
+            "stakingBalance": "1801593873610",
+            "stolenBlocks": []
+        },
+        "43": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "113239333",
+                    "finalRewards": "113246228"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "754",
+                    "finalRewards": "754"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "301971556",
+                    "finalRewards": "301989942"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "762486069",
+                    "finalRewards": "762532493"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "67945110",
+                    "finalRewards": "67949246"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "127952416",
+                "feeRewards": "138404758",
+                "looseRewards": "4",
+                "totalRewards": "266357178"
+            },
+            "estimatedTotalRewards": "1512000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "127960206",
+                "feeRewards": "138413184",
+                "looseRewards": "4",
+                "totalRewards": "266373394"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-92057",
+                "paid": "1512092057",
+                "realized": "1491092057",
+                "realizedDifference": "-21000000"
+            },
+            "stakingBalance": "1802553875613",
+            "stolenBlocks": []
+        },
+        "44": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "98089243",
+                    "finalRewards": "98089618"
+                },
+                "KT1AW983Ku4HQT6rxN4kmvm4nmQ6W9zGgbbE": {
+                    "balance": "2147000000",
+                    "estimatedRewards": "1403984",
+                    "finalRewards": "1403989"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "653",
+                    "finalRewards": "653"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "261571317",
+                    "finalRewards": "261572316"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "660474409",
+                    "finalRewards": "660476931"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "58854854",
+                    "finalRewards": "58855078"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "111561708",
+                "feeRewards": "120043829",
+                "looseRewards": "3",
+                "totalRewards": "231605540"
+            },
+            "estimatedTotalRewards": "1312000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "111562134",
+                "feeRewards": "120044287",
+                "looseRewards": "4",
+                "totalRewards": "231606425"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-5010",
+                "paid": "1312005010",
+                "realized": "1292671676",
+                "realizedDifference": "-19333334"
+            },
+            "stakingBalance": "1805702571318",
+            "stolenBlocks": []
+        },
+        "45": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "95150933",
+                    "finalRewards": "95152503"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "634",
+                    "finalRewards": "634"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "253735821",
+                    "finalRewards": "253740010"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "640689577",
+                    "finalRewards": "640700155"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "57091828",
+                    "finalRewards": "57092771"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "109034672",
+                "feeRewards": "116296532",
+                "looseRewards": "3",
+                "totalRewards": "225331207"
+            },
+            "estimatedTotalRewards": "1272000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "finalBakerRewards": {
+                "bondRewards": "109036472",
+                "feeRewards": "116298452",
+                "looseRewards": "3",
+                "totalRewards": "225334927"
+            },
+            "finalTotalRewards": {
+                "estimatedDifference": "-21000",
+                "paid": "1272021000",
+                "realized": "1272021000",
+                "realizedDifference": "0"
+            },
+            "stakingBalance": "1804711678328",
+            "stolenBlocks": [
+                {
+                    "fees": "0",
+                    "hash": "BKsdG72vCMzk5okt9cMmkyGZrzc2h26AWWDfCjtEyV4JGhGiF64",
+                    "level": 185386,
+                    "priority": 1,
+                    "reward": "16000000"
+                }
+            ]
+        },
+        "46": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "95382603"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "635"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "254353610"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "642249510"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "57230834"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "110203117",
+                "feeRewards": "116579688",
+                "looseRewards": "3",
+                "totalRewards": "226782808"
+            },
+            "estimatedTotalRewards": "1276000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "stakingBalance": "1805989699340",
+            "stolenBlocks": []
+        },
+        "47": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "95755361"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "638"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "255347631"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "644759441"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "57454493"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "111647146",
+                "feeRewards": "117035285",
+                "looseRewards": "5",
+                "totalRewards": "228682436"
+            },
+            "estimatedTotalRewards": "1282000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "stakingBalance": "1807418367016",
+            "stolenBlocks": []
+        },
+        "48": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "92249852"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "614"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "245999607"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "621155435"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "55351141"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "108492607",
+                "feeRewards": "112750739",
+                "looseRewards": "5",
+                "totalRewards": "221243351"
+            },
+            "estimatedTotalRewards": "1236000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "stakingBalance": "1808783373017",
+            "stolenBlocks": []
+        },
+        "49": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "95647085"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "637"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "255058893"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "644030370"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "57389526"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "162970541",
+                "feeRewards": "116902945",
+                "looseRewards": "3",
+                "totalRewards": "279873489"
+            },
+            "estimatedTotalRewards": "1332000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "stakingBalance": "1880036383037",
+            "stolenBlocks": []
+        },
+        "50": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "95436069"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "636"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "254496186"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "642609518"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "57262914"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "163549638",
+                "feeRewards": "116645036",
+                "looseRewards": "3",
+                "totalRewards": "280194677"
+            },
+            "estimatedTotalRewards": "1330000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "stakingBalance": "1881364146705",
+            "stolenBlocks": []
+        },
+        "51": {
+            "delegators": {
+                "KT1AV14rHeRdLG8DgxR11QpUVBUJcudpMKjE": {
+                    "balance": "150000000000",
+                    "estimatedRewards": "96366491"
+                },
+                "KT1Lebwj1QLFaD2AMfHN64kKxUXind2e8zYv": {
+                    "balance": "1000000",
+                    "estimatedRewards": "642"
+                },
+                "KT1MN9eMepaUFQYrZbpVUGejDt2Rq9FmgdWr": {
+                    "balance": "400000000000",
+                    "estimatedRewards": "256977309"
+                },
+                "KT1U3vUWJzVyNhx6V9RSw6h7z7GnJ7LLnR1M": {
+                    "balance": "1010010450000",
+                    "estimatedRewards": "648874420"
+                },
+                "KT1XeDeiR2BC4L8SUPY9saTf5eYfMY6nmTpx": {
+                    "balance": "90002000000",
+                    "estimatedRewards": "57821179"
+                }
+            },
+            "estimatedBakerRewards": {
+                "bondRewards": "166177729",
+                "feeRewards": "117782227",
+                "looseRewards": "3",
+                "totalRewards": "283959959"
+            },
+            "estimatedTotalRewards": "1344000000",
+            "fee": {
+                "denominator": 10,
+                "numerator": 1
+            },
+            "stakingBalance": "1882812146770",
+            "stolenBlocks": []
+        }
+    }
+}


### PR DESCRIPTION
Solution: this will be the canonical data representation moving
forward. hence committing it to the repository so that
the frontend can use it.